### PR TITLE
ModEntry ServerToggle and ButtonToggle Load Level Issue

### DIFF
--- a/Always On Server/ModEntry.cs
+++ b/Always On Server/ModEntry.cs
@@ -303,11 +303,11 @@ namespace Always_On_Server
                     var data = this.Helper.Data.ReadJsonFile<ModData>($"data/{Constants.SaveFolderName}.json") ?? new ModData();
 
                     // Set levels
-                    Game1.player.farmingLevel.Value = data.MiningLevel;
+                    Game1.player.farmingLevel.Value = data.FarmingLevel;
                     Game1.player.miningLevel.Value = data.MiningLevel;
-                    Game1.player.foragingLevel.Value = data.MiningLevel;
-                    Game1.player.fishingLevel.Value = data.MiningLevel;
-                    Game1.player.combatLevel.Value = data.MiningLevel;
+                    Game1.player.foragingLevel.Value = data.ForagingLevel;
+                    Game1.player.fishingLevel.Value = data.FishingLevel;
+                    Game1.player.combatLevel.Value = data.CombatLevel;
 
                     // Set EXP
                     Game1.player.experiencePoints[FarmingSkillNumber] = data.FarmingExperience;
@@ -396,11 +396,11 @@ namespace Always_On_Server
                         var data = this.Helper.Data.ReadJsonFile<ModData>($"data/{Constants.SaveFolderName}.json") ?? new ModData();
 
                         // Set levels
-                        Game1.player.farmingLevel.Value = data.MiningLevel;
+                        Game1.player.farmingLevel.Value = data.FarmingLevel;
                         Game1.player.miningLevel.Value = data.MiningLevel;
-                        Game1.player.foragingLevel.Value = data.MiningLevel;
-                        Game1.player.fishingLevel.Value = data.MiningLevel;
-                        Game1.player.combatLevel.Value = data.MiningLevel;
+                        Game1.player.foragingLevel.Value = data.ForagingLevel;
+                        Game1.player.fishingLevel.Value = data.FishingLevel;
+                        Game1.player.combatLevel.Value = data.CombatLevel;
 
                         // Set EXP
                         Game1.player.experiencePoints[FarmingSkillNumber] = data.FarmingExperience;


### PR DESCRIPTION
hello. Please understand that the expressions are strange due to Google Translator.

I'm really enjoying this mode, but there's a problem where all skill levels are changed to miner skill levels when turning off the server mode.

When I checked ModEntry.cs, I found that MiningLevel was added to all skill levels during the loading process. I modified it. Is this applicable?

Since I did not fully understand the code, additional modifications may be needed.